### PR TITLE
7 add try except in osget terminal size

### DIFF
--- a/bom_analysis/base.py
+++ b/bom_analysis/base.py
@@ -649,7 +649,7 @@ class DFClass(BaseClass, PrintParamsTable):
             return f"\n{tabulate(formated_list_of_params, headers='keys', tablefmt='fancy_grid')}"
         else:
             return "Empty DataFrame"
-    
+
     def to_dict(self):
         """Exports the data for storage in a json file.
 

--- a/bom_analysis/base.py
+++ b/bom_analysis/base.py
@@ -19,7 +19,7 @@ from bom_analysis.utils import (
     decoder,
     MaterialSelector,
     change_handler,
-    PrintParamsTable
+    PrintParamsTable,
 )
 
 
@@ -552,7 +552,7 @@ class DFClass(BaseClass, PrintParamsTable):
             return np.array([])
         else:
             return np.array(self.data.index)
-    
+
     @property
     def header(self):
         """

--- a/bom_analysis/base.py
+++ b/bom_analysis/base.py
@@ -625,7 +625,7 @@ class DFClass(BaseClass, PrintParamsTable):
             self.data.at[key, col] = val
 
     def __str__(self):
-        """Prints the information.
+        """Returns user readable representation of the data.
 
         To allow for printing i the console, the terminal size
         is checked and the dat wrapped to fit. Additionally,

--- a/bom_analysis/base.py
+++ b/bom_analysis/base.py
@@ -19,6 +19,7 @@ from bom_analysis.utils import (
     decoder,
     MaterialSelector,
     change_handler,
+    PrintParamsTable
 )
 
 
@@ -526,7 +527,7 @@ class BaseClass:
                 setattr(self, name, decoder(sub))
 
 
-class DFClass(BaseClass):
+class DFClass(BaseClass, PrintParamsTable):
     """The DFClass is included in BOM analysis to allow for
     data to be stored in a dataframe but with some additional
     functionality.
@@ -551,6 +552,13 @@ class DFClass(BaseClass):
             return np.array([])
         else:
             return np.array(self.data.index)
+    
+    @property
+    def header(self):
+        """
+        Used for printing the dataframe.
+        """
+        return self.vars
 
     @property
     def col_count(self):
@@ -616,7 +624,7 @@ class DFClass(BaseClass):
         for key, val in data_dict.items():
             self.data.at[key, col] = val
 
-    def __repr__(self):
+    def __str__(self):
         """Prints the information.
 
         To allow for printing i the console, the terminal size
@@ -628,36 +636,13 @@ class DFClass(BaseClass):
         str
             The string that will be output contianing a
             terminal fitted tabulate based dataframe.
-
-        Note
-        ----
-        When tabulate is updated we can use
-        terminal_size = os.get_terminal_size()
-        width = int(terminal_size.columns/(self._col_count+1))
-        widths = [width for i in range(0, self._col_count)]
-        tabulate(self.data, tablefmt="fancy_grid", maxcolwidths=widths)."""
-        terminal_size = os.get_terminal_size()
-        width = int((terminal_size.columns - 50) / (self.col_count))
-
-        def format(x):
-            if hasattr(x, "magnitude"):
-                x = Q_(np.format_float_scientific(x.magnitude, precision=4), x.units)
-
-            text_list = textwrap.wrap(str(x), width=width)
-            string = "".join([f"{text}\n" for text in text_list])
-            return string
-
-        display_data = self.data.copy(deep=True)
-        for i_col in range(0, display_data.shape[1]):
-            display_data.iloc[:, i_col] = display_data.iloc[:, i_col].apply(format)
-        string = ""
+        """
         if self.data is not None:
-            string += (
-                f'\n\n{tabulate(display_data.sort_index(), tablefmt="fancy_grid")}\n\n'
-            )
+            list_of_params = [data_dict for data_dict in self.data.to_dict().values()]
+            formated_list_of_params = self.format_params(list_of_params)
+            return f"\n{tabulate(formated_list_of_params, headers='keys', tablefmt='fancy_grid')}"
         else:
-            string += f"\n\nno data populated\n\n"
-        return string
+            return "Empty DataFrame"
 
     def to_dict(self):
         """Exports the data for storage in a json file.

--- a/bom_analysis/base.py
+++ b/bom_analysis/base.py
@@ -2,7 +2,6 @@ from builtins import getattr, hasattr
 import types
 from pathlib import Path
 import os
-import textwrap
 from getpass import getpass
 from typing import Union
 
@@ -558,7 +557,11 @@ class DFClass(BaseClass, PrintParamsTable):
         """
         Used for printing the dataframe.
         """
-        return self.vars
+        cols = self.data.columns.tolist()
+        header = ["index"]
+        for col_int in cols:
+            header.append(col_int)
+        return header
 
     @property
     def col_count(self):
@@ -638,12 +641,15 @@ class DFClass(BaseClass, PrintParamsTable):
             terminal fitted tabulate based dataframe.
         """
         if self.data is not None:
-            list_of_params = [data_dict for data_dict in self.data.to_dict().values()]
+            list_of_params = []
+            for key, data_dict in self.data.to_dict(orient="index").items():
+                data_dict["index"] = key
+                list_of_params.append(data_dict)
             formated_list_of_params = self.format_params(list_of_params)
             return f"\n{tabulate(formated_list_of_params, headers='keys', tablefmt='fancy_grid')}"
         else:
             return "Empty DataFrame"
-
+    
     def to_dict(self):
         """Exports the data for storage in a json file.
 

--- a/bom_analysis/parameters.py
+++ b/bom_analysis/parameters.py
@@ -1,4 +1,3 @@
-import os
 import pprint
 from typing import Union, Any
 
@@ -9,7 +8,7 @@ from tabulate import tabulate
 
 from bom_analysis import Q_, run_log
 from bom_analysis.base import BaseFramework
-from bom_analysis.utils import access_nested, encoder, decoder
+from bom_analysis.utils import access_nested, encoder, decoder, PrintParamsTable
 
 
 class MissingParamError(AttributeError):
@@ -416,7 +415,7 @@ class PintParam(FlexParam):
         return dump
 
 
-class ParameterFrame:
+class ParameterFrame(PrintParamsTable):
     """The Parameter class aims to be the primary method for storing parameters within the
     Engineering Objects. A version (either Pint integrated or not) is included with every
     Engineering Object using the attribute params. The default is with Pint integration
@@ -580,72 +579,6 @@ class ParameterFrame:
             a list in order of the headers for
             printing the parameter frame."""
         return self._data[self.order[-1]].fields
-
-    def format_params(self, list_of_params: list):
-        """Formats the dictionary representation of the parameters to allow
-        for nice string represntation.
-
-        If being used in a terminal, the size will be checked to split
-        the strings of the information in the parameter so that the
-        output does not extend over multiple lines (and can be read).
-        The in-built pint formater is used to convert the strings representing
-        a unit (if supplied) to symbolic i.e. meter to m.
-
-        Parameters
-        ----------
-        list_of_params : list
-            A list of dictionaries with the _data parameters.
-
-        Returns
-        -------
-        list
-            A formated list of dictionaries with the _data parameters.
-        """
-        formated_list_of_params = []
-        try:
-            terminal_size = os.get_terminal_size().columns
-            max_character = int(terminal_size / len(list_of_params[0]))
-        except OSError:
-            max_character = None
-        for param in list_of_params:
-            new_param = {}
-            if "unit" in param and param["unit"] is not None:
-                param["unit"] = format(Q_(param["unit"]).units, "~")
-            elif "unit" in param:
-                param["unit"] = "dimensionless"
-            for key in self.header:
-                split_string = self.new_line_in_string(param[key], max_character)
-                new_param[key] = split_string
-            formated_list_of_params.append(new_param)
-        return formated_list_of_params
-
-    def new_line_in_string(self, input: Any, max_character: int = None):
-        """Splits the input into multiple lines based on a supplied
-        max character interger.
-
-        Parameters
-        ----------
-        input : Any
-            The parameter item to be split.
-        max_character : int, optional
-            The maximum number of characters before adding the new
-            line, by default None.
-
-        Returns
-        -------
-        Any
-            The parameter item with the split accross new lines added.
-        """
-        if max_character is not None:
-            try:
-                lines = []
-                for i in range(0, len(input), max_character):
-                    lines.append(input[i : i + max_character])
-                return "\n".join(lines)
-            except TypeError:
-                return input
-        else:
-            return input
 
     def add_parameter(self, **kwargs):
         """Adds a parameter to the underlying _data, must be

--- a/bom_analysis/utils.py
+++ b/bom_analysis/utils.py
@@ -6,7 +6,7 @@ import itertools
 import logging
 from pathlib import Path
 import os
-from typing import Any
+from typing import Any, Union
 
 import json
 import numpy as np
@@ -434,7 +434,7 @@ class Translator:
 
 
 class PrintParamsTable:
-    def format_params(self, list_of_params: list):
+    def format_params(self, list_of_params: list) -> list:
         """Formats the dictionary representation of the parameters to allow
         for nice string represntation.
 
@@ -469,7 +469,7 @@ class PrintParamsTable:
             formated_list_of_params.append(new_param)
         return formated_list_of_params
 
-    def get_max_column_width(self, list_of_params: list):
+    def get_max_column_width(self, list_of_params: list) -> Union[int, None]:
         """Gets the maximum column size for printing of
         a tabular dataframe.
 
@@ -500,7 +500,7 @@ class PrintParamsTable:
         ):
             return None
 
-    def shorten_unit(self, quantity: Any):
+    def shorten_unit(self, quantity: Any) -> Any:
         """Shortens the format of the units in a pint unit
         and returns as string.
 
@@ -523,7 +523,7 @@ class PrintParamsTable:
         ):
             return quantity
 
-    def new_line_in_string(self, input: Any, max_character: int = None):
+    def new_line_in_string(self, input: Any, max_character: int = None) -> Any:
         """Splits the input into multiple lines based on a supplied
         max character interger.
 

--- a/bom_analysis/utils.py
+++ b/bom_analysis/utils.py
@@ -469,13 +469,48 @@ class PrintParamsTable:
         return formated_list_of_params
 
     def get_max_column_width(self, list_of_params: list):
+        """Gets the maximum column size for printing of
+        a tabular dataframe.
+
+        The maximum column size is important as it allows
+        a string to be split over multiple lines and, therefore,
+        displayed nicely.
+
+        Parameters
+        ----------
+        list_of_params : list
+            List of parameters that will be used to determine
+            the maximum size of the columns in the print.
+
+        Returns
+        -------
+        int
+            The maximum column size for a given terminal width.
+        None
+            If an OSError is raised (due to no terminal) or
+            an index error is raised (due to an empty input list).
+        """
         try:
             terminal_size = os.get_terminal_size().columns
             return int(terminal_size / len(list_of_params[0]))
         except (OSError, IndexError,):
             return None
 
-    def shorten_unit(self, quantity):
+    def shorten_unit(self, quantity: Any):
+        """Shortens the format of the units in a pint unit 
+        and returns as string.
+
+        Parameters
+        ----------
+        quantity : Any
+            Any input to be tried to have the units
+            converted to symbolic via the format.
+
+        Returns
+        -------
+        str
+            String for quantity with shortened units.
+        """
         try:
             return format(quantity, "~")
         except (ValueError, TypeError, ):

--- a/bom_analysis/utils.py
+++ b/bom_analysis/utils.py
@@ -432,6 +432,7 @@ class Translator:
             The input translations."""
         return list(cls._data.keys())
 
+
 class PrintParamsTable:
     def format_params(self, list_of_params: list):
         """Formats the dictionary representation of the parameters to allow
@@ -493,11 +494,14 @@ class PrintParamsTable:
         try:
             terminal_size = os.get_terminal_size().columns
             return int(terminal_size / len(list_of_params[0]))
-        except (OSError, IndexError,):
+        except (
+            OSError,
+            IndexError,
+        ):
             return None
 
     def shorten_unit(self, quantity: Any):
-        """Shortens the format of the units in a pint unit 
+        """Shortens the format of the units in a pint unit
         and returns as string.
 
         Parameters
@@ -513,7 +517,10 @@ class PrintParamsTable:
         """
         try:
             return format(quantity, "~")
-        except (ValueError, TypeError, ):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return quantity
 
     def new_line_in_string(self, input: Any, max_character: int = None):
@@ -543,6 +550,7 @@ class PrintParamsTable:
                 return input
         else:
             return input
+
 
 class UpdateDict:
     """Updating a dictionary with more control

--- a/bom_analysis/utils.py
+++ b/bom_analysis/utils.py
@@ -227,16 +227,16 @@ class MaterialSelector:
         a material can be selected based on a material str.
         """
         self.clear_database()
-        
+
     def clear_database(self):
-        """Clears the material databases within the materials 
+        """Clears the material databases within the materials
         selector.
-        
+
         Attributes
         ----------
         priority_order : np.ndarray
             An array contianing information about each of the material
-            data class.        
+            data class.
         """
         self.priority_order = np.array([], dtype=object)
 

--- a/bom_analysis/utils.py
+++ b/bom_analysis/utils.py
@@ -225,12 +225,18 @@ class MaterialSelector:
         """The material selector is a class that can be provided with
         a list of MaterialData classes in a priotised order from which
         a material can be selected based on a material str.
-
+        """
+        self.clear_database()
+        
+    def clear_database(self):
+        """Clears the material databases within the materials 
+        selector.
+        
         Attributes
         ----------
         priority_order : np.ndarray
             An array contianing information about each of the material
-            data class.
+            data class.        
         """
         self.priority_order = np.array([], dtype=object)
 

--- a/tests/test_Base.py
+++ b/tests/test_Base.py
@@ -448,14 +448,14 @@ class TestBaseDfClass(unittest.TestCase):
 
     def test_print_empty(self):
         df_wrap = bs.DFClass()
-        print(df_wrap)  
-
+        print(df_wrap)
 
     def test_print_correctly_with_pint(self):
         df_wrap = bs.DFClass()
         df_wrap.create_df(4, "foo", "bar")
         df_wrap.data.at["foo", 1] = Q_(1000, "meter*meter*kilogram*litre")
         print(df_wrap)
+
 
 if __name__ == "__main__":
 

--- a/tests/test_Base.py
+++ b/tests/test_Base.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from bom_analysis import Q_
 import bom_analysis.base as bs
 from bom_analysis.base import BaseConfig as Config
 from bom_analysis.bom import Assembly, Component
@@ -438,6 +439,23 @@ class TestOldFormatLoad(unittest.TestCase):
         phone.plot_hierarchy()
         print(phone.params)
 
+
+class TestBaseDfClass(unittest.TestCase):
+    def test_print_correctly(self):
+        df_wrap = bs.DFClass()
+        df_wrap.create_df(4, "foo", "bar")
+        print(df_wrap)
+
+    def test_print_empty(self):
+        df_wrap = bs.DFClass()
+        print(df_wrap)  
+
+
+    def test_print_correctly_with_pint(self):
+        df_wrap = bs.DFClass()
+        df_wrap.create_df(4, "foo", "bar")
+        df_wrap.data.at["foo", 1] = Q_(1000, "meter*meter*kilogram*litre")
+        print(df_wrap)
 
 if __name__ == "__main__":
 

--- a/tests/test_Parameters.py
+++ b/tests/test_Parameters.py
@@ -454,6 +454,10 @@ class TestParameters(unittest.TestCase):
         pf.add_parameter(var="length", value=1, hello="world")
         pf.length = 1.0
 
+    def test_empty_print(self):
+        pf = par.ParameterFrame()
+        print(pf)
+
 
 @pytest.mark.integrationtest
 class TestPintameters(unittest.TestCase):

--- a/tests/test_Utils.py
+++ b/tests/test_Utils.py
@@ -1,7 +1,8 @@
 import copy
 import unittest
 
-from bom_analysis.utils import UpdateDict, Translator, access_nested
+from bom_analysis import Q_
+from bom_analysis.utils import UpdateDict, Translator, access_nested, PrintParamsTable
 
 
 class TestMerge(unittest.TestCase):
@@ -95,6 +96,15 @@ class TestFunctions(unittest.TestCase):
         b = access_nested(a, ["foo", "None_please", "hello"])
         assert b is None
 
+
+class TestPrintParamsTable:
+    def test_shorten_unit(self):
+        ppt = PrintParamsTable()
+        assert ppt.shorten_unit("hello") == "hello"
+        assert ppt.shorten_unit(12345.6) == 12345.6
+        assert ppt.shorten_unit(12345) == 12345
+        assert ppt.shorten_unit(None) == None
+        assert ppt.shorten_unit(Q_("1000 meter*kilogram")) == "1000 kg * m"
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Utils.py
+++ b/tests/test_Utils.py
@@ -106,5 +106,6 @@ class TestPrintParamsTable:
         assert ppt.shorten_unit(None) == None
         assert ppt.shorten_unit(Q_("1000 meter*kilogram")) == "1000 kg * m"
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Description

Changes the two different str for the DFClass and parameters so that they use a single formatter with changes to symbolic units and a get terminal size change.

Fixes #7 #9 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] local tests
- [x] RaBBIT tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
